### PR TITLE
Added option for variable size Vierkandles

### DIFF
--- a/app/Console/Commands/DailyPuzzles.php
+++ b/app/Console/Commands/DailyPuzzles.php
@@ -3,6 +3,7 @@
 namespace App\Console\Commands;
 
 use App\Models\Vierkandle;
+use Carbon\Carbon;
 use Illuminate\Console\Command;
 
 class DailyPuzzles extends Command
@@ -12,7 +13,7 @@ class DailyPuzzles extends Command
      *
      * @var string
      */
-    protected $signature = 'app:daily-puzzles';
+    protected $signature = 'app:daily-puzzles {size} {--date=}';
 
     /**
      * The console command description.
@@ -27,7 +28,10 @@ class DailyPuzzles extends Command
     public function handle() : void
     {
         info('Creating daily puzzles.');
-        Vierkandle::factory()->create();
+        Vierkandle::factory()->create([
+            'boardsize' => $this->argument('size'),
+            'date' => $this->option('date') ?? Carbon::tomorrow()]
+        );
         info('Created vierkandle for tomorrow.');
         info('Done.');
     }

--- a/app/Http/Controllers/VierkandleController.php
+++ b/app/Http/Controllers/VierkandleController.php
@@ -26,8 +26,14 @@ class VierkandleController extends Controller
     public function list()
     {
         return Inertia::render('Vierkandle/List', [
-            'today' => Vierkandle::query()->where('date', Carbon::today())->first()->setAppends(['solutions', 'solution_count']),
-            'vierkandles' => Vierkandle::query()->where('date', '!=', Carbon::today())->orderBy('date', 'desc')->get()->each->setAppends(['solutions', 'solution_count']),
+            'vierkandlesBySize' => Vierkandle::query()
+                ->where('date', '<=', Carbon::now()->format('Y-m-d'))
+                ->where('letters', "!=", "")
+                ->orderBy('date', 'desc')
+                ->get()
+                ->each
+                ->setAppends(['solutions', 'solution_count'])
+                ->groupBy('boardsize')
         ]);
     }
 

--- a/database/migrations/2024_01_18_093941_add_boardsize_to_vierkandles_table.php
+++ b/database/migrations/2024_01_18_093941_add_boardsize_to_vierkandles_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('vierkandles', function (Blueprint $table) {
+            $table->string('boardsize')->default(4)->after('letters');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('vierkandles', function (Blueprint $table) {
+            $table->dropColumn("boardsize");
+        });
+    }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-    "name": "Bambuzzle",
+    "name": "html",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {

--- a/resources/js/Components/Vierkandle/VierkandlePreview.vue
+++ b/resources/js/Components/Vierkandle/VierkandlePreview.vue
@@ -3,30 +3,25 @@ import {useVierkandleStorage} from "@/Composables/useVierkandleStorage";
 import {computed} from "vue";
 
 const props = defineProps<{
-    title?: string,
     routeName?: string,
-    vierkandle: {
-        id: number,
-        date: string,
-        letters: string,
-        solution_count: number,
-    },
+    vierkandle: App.Vierkandle
 }>()
 
 const { vierkandleStorage } = useVierkandleStorage(props.vierkandle);
 const solutionsFound = computed(() => vierkandleStorage.value.words.length);
+const today = (new Date(props.vierkandle.date)).toDateString() == (new Date()).toDateString();
 </script>
 
 <template>
     <a class="relative hover:opacity-70" :href="routeName ? route(routeName) : route('show', {vierkandle: vierkandle.id})">
-        <div class="flex flex-col items-center rounded-lg px-2 pb-2 bg-gray-200 dark:bg-gray-600"
-            :class="solutionsFound == vierkandle.solution_count ? 'opacity-30' : ''">
-            <div>{{ title ?? vierkandle.date }}</div>
-            <div class="grid grid-cols-4 grid-rows-4 gap-1">
+        <div class="flex flex-col items-center rounded-lg px-4 pt-2 pb-3 bg-gray-200 dark:bg-gray-600 border-2 border-solid border-gray-400 dark:border-gray-500"
+            :class="{'opacity-30': solutionsFound == vierkandle.solution_count, 'dark:border-red-500 border-red-500 border-dashed': today}">
+            <div class="mb-1">{{ today ? 'Vandaag' : vierkandle.date }}</div>
+            <div class="grid vierkandle-grid gap-1">
                 <div v-for="letter in vierkandle.letters" class="w-4 h-4 text-xs rounded bg-gray-300 dark:bg-gray-700 align-middle text-center">{{ letter }}</div>
             </div>
             <div
-                class="w-full h-4 rounded overflow-hidden border border-black dark:border-white mt-2 relative">
+                class="w-full h-4 rounded overflow-hidden border border-gray-500 mt-2 relative">
                 <div class="absolute h-full bg-red-500 transition-all"
                      :style="`width: ${solutionsFound/vierkandle.solution_count*100}%`"></div>
             </div>
@@ -36,5 +31,8 @@ const solutionsFound = computed(() => vierkandleStorage.value.words.length);
 </template>
 
 <style scoped>
-
+.vierkandle-grid {
+    grid-template-rows: repeat(v-bind('props.vierkandle.boardsize'), minmax(0, 1fr));
+    grid-template-columns: repeat(v-bind('props.vierkandle.boardsize'), minmax(0, 1fr));
+}
 </style>

--- a/resources/js/Layouts/BasicLayout.vue
+++ b/resources/js/Layouts/BasicLayout.vue
@@ -241,14 +241,14 @@ onUnmounted(() => {
             </nav>
 
             <!-- Page Heading -->
-            <header v-if="$slots.header" class="bg-white dark:bg-gray-800 shadow">
+            <header v-if="$slots.header" class="bg-white dark:bg-gray-800 dark:text-white shadow">
                 <div class="max-w-7xl mx-auto py-4 px-4 sm:px-6 lg:px-8 font-medium text-xl">
                     <slot name="header"/>
                 </div>
             </header>
 
             <!-- Page Content -->
-            <main class="relative flex-grow flex-shrink overflow-hidden">
+            <main class="relative flex-grow flex-shrink overflow-auto">
                 <slot/>
             </main>
         </div>

--- a/resources/js/Pages/Vierkandle/Index.vue
+++ b/resources/js/Pages/Vierkandle/Index.vue
@@ -6,7 +6,6 @@ import Checkbox from "@/Components/Checkbox.vue";
 import BasicLayout from "@/Layouts/BasicLayout.vue";
 import {usePage} from "@inertiajs/vue3";
 import {useVierkandleStorage} from "@/Composables/useVierkandleStorage";
-import axios from "axios";
 
 const props = defineProps<{
     vierkandle: App.Vierkandle,
@@ -50,7 +49,7 @@ onMounted(() => {
 
 const letters = computed(() => {
     const letters: { letter: string, start: number, includes: number }[] = [];
-    for (let i = 0; i < 16; i++) {
+    for (let i = 0; i < props.vierkandle.boardsize ** 2; i++) {
         const letter = props.vierkandle.letters[i];
         letters.push({letter, start: 0, includes: 0});
     }
@@ -184,13 +183,13 @@ const recFindChain = (chain: number[], word: string): number[] => {
 
 const findNeighbours = (index: number): number[] => {
     const neighbours = [];
-    for (let i = -5; i <= 5; i++) {
+    for (let i = -(props.vierkandle.boardsize + 1); i <= props.vierkandle.boardsize + 1; i++) {
         if (i === 0) {
             continue;
         }
         const neighbour = index + i;
-        if (neighbour >= 0 && neighbour < 16) {
-            if (Math.abs(index % 4 - neighbour % 4) <= 1) {
+        if (neighbour >= 0 && neighbour < props.vierkandle.boardsize ** 2) {
+            if (Math.abs(index % props.vierkandle.boardsize - neighbour % props.vierkandle.boardsize) <= 1) {
                 neighbours.push(neighbour);
             }
         }
@@ -349,7 +348,7 @@ const chainToInput = () => {
                                     </a>
                                 </div>
                                 <div
-                                    class="mx-auto grid grid-cols-4 grid-rows-4 gap-2 w-fit transition-transform duration-500 select-none"
+                                    class="mx-auto grid vierkandle-grid gap-2 w-fit transition-transform duration-500 select-none"
                                     :style="`transform: rotate(${rotation*90}deg)`">
                                     <Vierkand v-for="(letter, i) in letters"
                                               class="transition-transform duration-500"
@@ -383,3 +382,10 @@ const chainToInput = () => {
         </div>
     </BasicLayout>
 </template>
+
+<style scoped>
+.vierkandle-grid {
+    grid-template-rows: repeat(v-bind('props.vierkandle.boardsize'), minmax(0, 1fr));
+    grid-template-columns: repeat(v-bind('props.vierkandle.boardsize'), minmax(0, 1fr));
+}
+</style>

--- a/resources/js/Pages/Vierkandle/List.vue
+++ b/resources/js/Pages/Vierkandle/List.vue
@@ -1,23 +1,19 @@
 <script setup lang="ts">
-import AppLayout from '@/Layouts/AppLayout.vue';
-import Vierkand from "@/Components/Vierkandle/Vierkand.vue";
-import {computed, onMounted, ref} from "vue";
-import Connection from "@/Components/Vierkandle/Connection.vue";
-import Checkbox from "@/Components/Checkbox.vue";
-import InputLabel from "@/Components/InputLabel.vue";
 import BasicLayout from "@/Layouts/BasicLayout.vue";
-import NavLink from "@/Components/NavLink.vue";
 import VierkandlePreview from "@/Components/Vierkandle/VierkandlePreview.vue";
-import PrimaryButton from "@/Components/PrimaryButton.vue";
+import SecondaryButton from "@/Components/SecondaryButton.vue";
+import PrimaryButton from "@/Components/PrimaryButton.vue"
+import {ref} from "vue";
 
 defineProps<{
-    today?: App.Vierkandle,
-    vierkandles: App.Vierkandle[],
+    vierkandlesBySize: Object[App.Vierkandle[]],
 }>()
 
 const migrateData = () => {
     window.location.href = route('migrate.child')
 }
+
+let selected = ref(4)
 </script>
 
 <template>
@@ -25,14 +21,18 @@ const migrateData = () => {
         <template #header>
             Alle Vierkandles
         </template>
-        <div class="py-4 dark:text-white absolute w-full h-full overflow-hidden">
-            <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 h-full">
-                <div class="bg-white dark:bg-gray-800 h-full overflow-y-auto shadow-xl p-5 sm:rounded-lg">
-                    <div class="mb-10">Mis je voortgang sinds de update? <PrimaryButton @click="migrateData">Migreer data</PrimaryButton></div>
-                    <div class="flex flex-wrap gap-5">
-                        <VierkandlePreview v-if="today" :vierkandle="today" title="Vandaag" route-name="index" />
-
-                        <VierkandlePreview v-for="vierkandle in vierkandles" :vierkandle="vierkandle" />
+        <div class="py-4 dark:text-white">
+            <div class="max-w-7xl mx-auto sm:px-6 lg:px-8 flex flex-col">
+                <div class="ml-auto mr-2"><span class="mr-3">Mis je voortgang sinds de update?</span><SecondaryButton @click="migrateData">Migreer data</SecondaryButton></div>
+                <div class="mx-auto mt-2 mb-5">
+                    <SecondaryButton class="mr-4" :class="{'border-2 border-gray-500 dark:border-gray-300': key == selected}" @click="selected = key" v-for="(vierkandles, key) in vierkandlesBySize">{{key}}×{{key}}</SecondaryButton>
+                </div>
+                <div v-for="(vierkandles, key) in vierkandlesBySize">
+                    <div v-if="key == selected" class="mx-auto bg-white dark:bg-gray-800 shadow-xl p-5 mb-5 sm:rounded-lg">
+                        <h1 class="ml-2 text-2xl mb-2 font-bold">Alle {{key}}×{{key}} Vierkandles:</h1>
+                        <div class="flex flex-wrap gap-x-3 gap-y-2 max-h-[60svh] overflow-auto">
+                            <VierkandlePreview class="min-w-[8rem]" v-for="vierkandle in vierkandles" :vierkandle="vierkandle" />
+                        </div>
                     </div>
                 </div>
             </div>

--- a/resources/js/types/vierkandle.ts
+++ b/resources/js/types/vierkandle.ts
@@ -3,6 +3,7 @@ namespace App {
         id: number;
         letters: string;
         date: date;
+        boardsize: int;
         solutions_count: number;
         solutions?: VierkandleSolution[];
     }


### PR DESCRIPTION
The vierkandles table now has a  `boardsize` column that defines the size of the Vierkandle, the list view is grouped by `boardsize` and the `artisan app:daily-puzzles` command now has a `size` argument and `--date` option. As the default `boardsize` is 4 it should not break any previously generated boards. The list view also no longer shows future boards, only today's and previous days'.

### Preview of the new list page:
![image](https://github.com/JonaMata/Vierkandle/assets/21026046/877fa9aa-6072-4b94-9976-68fbc3cd1963)
![image](https://github.com/JonaMata/Vierkandle/assets/21026046/880c065b-c439-442d-b59f-66f487ed185f)




